### PR TITLE
Add eurocrypt 2022 event

### DIFF
--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -19,7 +19,7 @@ const Events: NextPage = () => {
             Cryptographic Frontier 2022, Trondheim
           </Heading>
 
-          <Text>
+          <Text mb={10}>
             <Link
               href='https://sites.google.com/view/cryptographic-frontier-2022/'
               color='brand.lightblue'

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -16,6 +16,21 @@ const Events: NextPage = () => {
 
         <Stack mb={6}>
           <Heading as='h2' size='lg' fontWeight={600} mb={2}>
+            Cryptographic Frontier 2022, Trondheim
+          </Heading>
+
+          <Text>
+            <Link
+              href='https://sites.google.com/view/cryptographic-frontier-2022/'
+              color='brand.lightblue'
+              _hover={{ color: 'brand.orange', textDecoration: 'underline' }}
+              isExternal
+            >
+              <strong>Open Problems in Decentralized Computation at Eurocrypt 2022:</strong>
+            </Link>{' '}
+            this workshop brings the most interesting and challenging open cryptographic questions that Ethereum, Filecoin and other blockchain systems face, to the attention of academia.  We will cover a large spectrum of research topics, such as vector commitments, SNARKs, shuffles, authenticated data structures and more. We will start the day with an update on to the problems discussed at last year's workshop.
+          </Text>
+          <Heading as='h2' size='lg' fontWeight={600} mb={2}>
             Cryptographic Frontier 2021, Zagreb
           </Heading>
 

--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -28,7 +28,7 @@ const Events: NextPage = () => {
             >
               <strong>Open Problems in Decentralized Computation at Eurocrypt 2022:</strong>
             </Link>{' '}
-            this workshop brings the most interesting and challenging open cryptographic questions that Ethereum, Filecoin and other blockchain systems face, to the attention of academia.  We will cover a large spectrum of research topics, such as vector commitments, SNARKs, shuffles, authenticated data structures and more. We will start the day with an update on to the problems discussed at last year's workshop.
+            this workshop brings the most interesting and challenging open cryptographic questions that Ethereum, Filecoin and other blockchain systems face, to the attention of academia.  We will cover a large spectrum of research topics, such as vector commitments, SNARKs, shuffles, authenticated data structures and more. We will start the day with an update on to the problems discussed at last year&apos;s workshop.
           </Text>
           <Heading as='h2' size='lg' fontWeight={600} mb={2}>
             Cryptographic Frontier 2021, Zagreb


### PR DESCRIPTION
Added another event for the event page.

I think the page is a bit too cramped up right now, but I didn't know how to add vertical whitespace between the two events. Feel free to merge and fix and I will see how it was done! :)

There is also no concept of "past" and "future" event atm. Perhaps that's OK.